### PR TITLE
Provide a way to use a primary private key that isn't stored in blocktrail servers

### DIFF
--- a/examples/not_so_simple_payment_api_usage.js
+++ b/examples/not_so_simple_payment_api_usage.js
@@ -1,0 +1,90 @@
+var blocktrail = require('blocktrail-sdk');
+var bitcoin = require('bitcoinjs-lib'),
+    bip39 = require("bip39");
+
+var client = blocktrail.BlocktrailSDK({
+    apiKey : "YOUR_APIKEY_HERE",
+    apiSecret : "YOUR_APISECRET_HERE",
+    testnet : true
+});
+
+/*
+ * this example is for when you're storing the primary private and backup public key yourself
+ */
+var primaryPrivateKey = bitcoin.HDNode.fromBase58("tprv8ZgxMBicQKsPdMD2AYgpezVQZNi5kxsRJDpQWc5E9mxp747KgzekJbCkvhqv6sBTDErTjkWqZdY14rLP1YL3cJawEtEp2dufHxPhr1YUoeS", bitcoin.networks.testnet);
+var backupPublicKey = bitcoin.HDNode.fromBase58("tpubD6NzVbkrYhZ4Y6Ny2VF2o5wkBGuZLQAsGPn88Y4JzKZH9siB85txQyYq3sDjRBFwnE1YhdthmHWWAurJu7EetmdeJH9M5jz3Chk7Ymw2oyf", bitcoin.networks.testnet);
+
+var sendTransaction = function(wallet) {
+    wallet.getNewAddress(function(err, address, path) {
+        if (err) {
+            return console.log("getNewAddress ERR", err);
+        }
+
+        console.log('new address', address, path);
+
+        var pay = {};
+        pay[address] = blocktrail.toSatoshi(0.001);
+
+        wallet.pay(pay, function(err, result) {
+            if (err) {
+                return console.log("pay ERR", err);
+            }
+
+            console.log('transaction', result);
+        });
+    });
+};
+
+var action = 'default';
+
+if (action === 'create') {
+    client.createNewWallet({
+        identifier: "example-wallet",
+        keyIndex: 9999,
+        primaryPrivateKey: primaryPrivateKey,
+        backupPublicKey: backupPublicKey,
+    }, function(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys) {
+            if (err) {
+                return console.log("createNewWallet ERR", err);
+            }
+
+            console.log('primary mnemonic', primaryMnemonic);
+            console.log('backup mnemonic', backupMnemonic);
+            console.log('blocktrail pubkeys', blocktrailPubKeys);
+
+            wallet.doDiscovery(function(err, confirmed, unconfirmed) {
+                if (err) {
+                    return console.log("doDiscovery ERR", err);
+                }
+
+                console.log('confirmed balance', confirmed);
+                console.log('unconfirmed balance', unconfirmed);
+
+                sendTransaction(wallet);
+            });
+        }
+    );
+} else {
+    client.initWallet({
+        identifier: "example-wallet",
+        keyIndex: 9999,
+        primaryPrivateKey: primaryPrivateKey,
+        primaryMnemonic: false
+    }, function(err, wallet) {
+            if (err) {
+                return console.log('initWallet ERR', err);
+            }
+
+            wallet.getBalance(function(err, confirmed, unconfirmed) {
+                if (err) {
+                    return console.log("getBalance ERR", err);
+                }
+
+                console.log('confirmed balance', confirmed);
+                console.log('unconfirmed balance', unconfirmed);
+
+                sendTransaction(wallet);
+            });
+        }
+    );
+}

--- a/examples/simple_payment_api_usage.js
+++ b/examples/simple_payment_api_usage.js
@@ -30,7 +30,11 @@ var sendTransaction = function(wallet) {
 var action = 'default';
 
 if (action === 'create') {
-    client.createNewWallet("example-wallet", "example-strong-password", 9999, function(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys) {
+    client.createNewWallet({
+        indentifier: "example-wallet",
+        passphrase: "example-strong-password",
+        keyIndex: 9999
+    }, function(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys) {
         if (err) {
             return console.log("createNewWallet ERR", err);
         }
@@ -51,7 +55,10 @@ if (action === 'create') {
         });
     });
 } else {
-    client.initWallet("example-wallet", "example-strong-password", function(err, wallet) {
+    client.initWallet({
+        identifier: "example-wallet",
+        passphrase: "example-strong-password"
+    }, function(err, wallet) {
         if (err) {
             return console.log('initWallet ERR', err);
         }

--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -392,136 +392,257 @@ APIClient.prototype.unsubscribeNewBlocks = function(identifier, cb) {
 /**
  * initialize an existing wallet
  *
+ * Either takes two argument:
+ * @param options       object      {}
+ * @param cb            function    callback(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys)
+ *
+ * Or takes three arguments (old, deprecated syntax):
  * @param identifier    string      the wallet identifier to be initialized
  * @param passphrase    string      the password to decrypt the mnemonic with
- * @param cb            function    callback(err, wallet)
+ * @param cb            function    callback(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys)
+ * 
  * @returns {q.Promise}
  */
-APIClient.prototype.initWallet = function(identifier, passphrase, cb) {
+APIClient.prototype.initWallet = function(options, cb) {
     var self = this;
 
+    if (typeof(options) !== "object") {
+        // get the old-style arguments
+        options = {
+            identifier: arguments[0],
+            passphrase: arguments[1]
+        };
+
+        cb = arguments[2];
+    }
+
     var deferred = q.defer();
-    deferred.promise.nodeify(cb);
+    deferred.promise.spreadNodeify(cb);
 
-    self.client.get("/wallet/" + identifier, null, true, function(err, result) {
-        if (err) {
+    // wrapping in function(){}() so that we can use return on errors
+    (function() {
+        var network = self.testnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin;
+
+        var identifier = options.identifier;
+
+        if (!identifier) {
+            return deferred.reject(new Error("Identifier is required"));
+        }
+
+        self.client.get("/wallet/" + identifier, null, true).then(function(result) {
+            var keyIndex = options.keyIndex || result.key_index;
+            var passphrase = options.passphrase || options.password;
+
+            var primaryMnemonic = typeof(options.primaryMnemonic) !== "undefined" ? options.primaryMnemonic : result.primary_mnemonic;
+            var primaryPrivateKey = options.primaryPrivateKey;
+
+            if (primaryMnemonic && primaryPrivateKey) {
+                return deferred.reject(new Error("Can't specify Primary Mnemonic and Primary PrivateKey"));
+            }
+
+            if (!primaryMnemonic && !primaryPrivateKey) {
+                return deferred.reject(new Error("Can't init wallet with Primary Mnemonic or Primary PrivateKey"));
+            }
+
+            if (primaryMnemonic && !passphrase) {
+                return deferred.reject(new Error("Can't init wallet with Primary Mnemonic without a passphrase"));
+            }
+
+            if (primaryPrivateKey && !(primaryPrivateKey instanceof bitcoin.HDNode)) {
+                primaryPrivateKey = bitcoin.HDNode.fromBase58(primaryPrivateKey, network);
+            } else if (!primaryPrivateKey) {
+                primaryPrivateKey = bitcoin.HDNode.fromSeedBuffer(bip39.mnemonicToSeed(primaryMnemonic, passphrase), network);
+            }
+
+            var backupPublicKey = bitcoin.HDNode.fromBase58(result.backup_public_key[0], network);
+            backupPublicKey = [backupPublicKey.toBase58(), "M"];
+
+            // create a checksum of our private key which we'll later use to verify we used the right password
+            var checksum = primaryPrivateKey.getAddress().toBase58Check();
+
+            // check if we've used the right passphrase
+            if (checksum != result.checksum) {
+                return deferred.reject(new Error("Checksum [" + checksum + "] does not match [" + result.checksum + "], most likely due to incorrect password"));
+            }
+
+            // initialize wallet
+            var wallet = new Wallet(
+                self,
+                identifier,
+                primaryMnemonic,
+                primaryPrivateKey,
+                backupPublicKey,
+                result.blocktrail_public_keys,
+                keyIndex,
+                self.testnet
+            );
+
+            // if the response suggests we should upgrade to a different blocktrail cosigning key then we should
+            if (result.upgrade_key_index) {
+                wallet.upgradeKeyIndex(result.upgrade_key_index);
+            }
+
+            return deferred.resolve(wallet);
+        })
+        .fail(function(err) {
             return deferred.reject(err);
-        }
-
-        // convert the mnemonic to a seed using BIP39 and then to a HDKey
-        var primaryPrivateKey = bitcoin.HDNode.fromSeedBuffer(
-            bip39.mnemonicToSeed(result.primary_mnemonic, passphrase),
-            self.testnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin
-        );
-
-        // create checksum (address) of the primary private key to be compared with the stored checksum
-        var checksum = primaryPrivateKey.getAddress().toBase58Check();
-
-        // check if we've used the right passphrase
-        if (checksum != result.checksum) {
-            return deferred.reject(new Error("Checksum [" + checksum + "] does not match [" + result.checksum + "], most likely due to incorrect password"));
-        }
-
-        // initialize wallet
-        var wallet = new Wallet(
-            self,
-            identifier,
-            result.primary_mnemonic,
-            primaryPrivateKey,
-            result.backup_public_key,
-            result.blocktrail_public_keys,
-            result.key_index,
-            self.testnet
-        );
-
-        // if the response suggests we should upgrade to a different blocktrail cosigning key then we should
-        if (result.upgrade_key_index) {
-            wallet.upgradeKeyIndex(result.upgrade_key_index);
-        }
-
-        return deferred.resolve(wallet);
-    });
+        });
+    })();
 
     return deferred.promise;
 };
-
 /**
  * create a new wallet
  *   - will generate a new primary seed (with password) and backup seed (without password)
  *   - send the primary seed (BIP39 'encrypted') and backup public key to the server
  *   - receive the blocktrail co-signing public key from the server
  *
+ * Either takes two argument:
+ * @param options       object      {}
+ * @param cb            function    callback(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys)
+ *
+ * Or takes four arguments (old, deprecated syntax):
  * @param identifier    string      the wallet identifier to be initialized
  * @param passphrase    string      the password to decrypt the mnemonic with
  * @param keyIndex      int         override for the blocktrail cosign key to use (for development purposes)
  * @param cb            function    callback(err, wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys)
  * @returns {q.Promise}
  */
-APIClient.prototype.createNewWallet = function(identifier, passphrase, keyIndex, cb) {
+APIClient.prototype.createNewWallet = function(options, cb) {
     var self = this;
 
-    // keyIndex is optional
-    if (typeof keyIndex == "function") {
-        cb = keyIndex;
-        keyIndex = null;
+    if (typeof(options) !== "object") {
+        // get the old-style arguments
+        var identifier = arguments[0];
+        var passphrase = arguments[1];
+        var keyIndex = arguments[2];
+        cb = arguments[3];
+
+        // keyIndex is optional
+        if (typeof keyIndex == "function") {
+            cb = keyIndex;
+            keyIndex = null;
+        }
+
+        options = {
+            identifier: identifier,
+            passphrase: passphrase,
+            keyIndex: keyIndex
+        };
     }
 
     var deferred = q.defer();
-
     deferred.promise.spreadNodeify(cb);
 
-    // default to keyIndex = 0
-    keyIndex = keyIndex || 0;
+    // wrapping in function(){}() so that we can use return on errors
+    (function() {
+        var network = self.testnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin;
 
-    // create new primary seed
-    var primaryMnemonic = bip39.generateMnemonic(512);
-    var primaryPrivateKey = bitcoin.HDNode.fromSeedBuffer(
-        bip39.mnemonicToSeed(primaryMnemonic, passphrase),
-        self.testnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin
-    );
-    var primaryPublicKey = primaryPrivateKey.deriveHardened(keyIndex).neutered();
-    primaryPublicKey = [primaryPublicKey.toBase58(), "M/" + keyIndex + "'"];
+        var identifier = options.identifier;
+        var keyIndex = options.keyIndex || 0;
+        var passphrase = options.passphrase || options.password;
 
-    // create new backup seed
-    var backupMnemonic = bip39.generateMnemonic(512);
-    var backupPrivateKey = bitcoin.HDNode.fromSeedBuffer(
-        bip39.mnemonicToSeed(backupMnemonic, ""),
-        self.testnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin
-    );
-    var backupPublicKey = backupPrivateKey.neutered();
-    backupPublicKey = [backupPublicKey.toBase58(), "M"];
-
-    // create a checksum of our private key which we'll later use to verify we used the right password
-    var checksum = primaryPrivateKey.getAddress().toBase58Check();
-
-    // send the public keys to the server to store them
-    //  and the mnemonic, which is safe because it's useless without the password
-    self._createNewWallet(identifier, primaryPublicKey, backupPublicKey, primaryMnemonic, checksum, keyIndex, function(err, result) {
-        if (err) {
-            return deferred.reject(err);
+        if (!identifier) {
+            return deferred.reject(new Error("Identifier is required"));
         }
 
-        // received the blocktrail public keys
-        var blocktrailPubKeys = result.blocktrail_public_keys;
+        var primaryMnemonic = options.primaryMnemonic;
+        var primaryPrivateKey = options.primaryPrivateKey;
 
-        var wallet = new Wallet(
-            self,
+        var storePrimaryMnemonic = options.storePrimaryMnemonic;
+
+        if (primaryMnemonic && primaryPrivateKey) {
+            return deferred.reject(new Error("Can't specify Primary Mnemonic and Primary PrivateKey"));
+        }
+
+        if (!primaryMnemonic && !primaryPrivateKey) {
+            if (!passphrase) {
+                return deferred.reject(new Error("Can't generate Primary Mnemonic without a passphrase"));
+            } else {
+                primaryMnemonic = bip39.generateMnemonic(512);
+                if (storePrimaryMnemonic !== false) {
+                    storePrimaryMnemonic = true;
+                }
+            }
+        }
+
+        if (storePrimaryMnemonic && primaryMnemonic && !passphrase) {
+            return deferred.reject(new Error("Can't store Primary Mnemonic on server without a passphrase"));
+        }
+
+        if (primaryPrivateKey && !(primaryPrivateKey instanceof  bitcoin.HDNode)) {
+            primaryPrivateKey = bitcoin.HDNode.fromBase58(primaryPrivateKey, network);
+        } else if(!primaryPrivateKey) {
+            primaryPrivateKey = bitcoin.HDNode.fromSeedBuffer(bip39.mnemonicToSeed(primaryMnemonic, passphrase), network);
+        }
+
+        // unset it it if we're not planning to store it
+        if (!storePrimaryMnemonic) {
+            primaryMnemonic = null;
+        }
+
+        var primaryPublicKey = primaryPrivateKey.deriveHardened(keyIndex).neutered();
+        primaryPublicKey = [primaryPublicKey.toBase58(), "M/" + keyIndex + "'"];
+
+        var backupMnemonic = options.backupMnemonic;
+        var backupPublicKey = options.backupPublicKey;
+
+        if (backupMnemonic && backupPublicKey) {
+            return deferred.reject(new Error("Can't specify Backup Mnemonic and Backup PrivateKey"));
+        }
+
+        if (!backupMnemonic && !backupPublicKey) {
+            backupMnemonic = bip39.generateMnemonic(512);
+        }
+
+        if (backupPublicKey && !(backupPublicKey instanceof bitcoin.HDNode)) {
+            backupPublicKey = bitcoin.HDNode.fromBase58(backupPublicKey, network);
+        } else if (!backupPublicKey) {
+            var backupPrivateKey = bitcoin.HDNode.fromSeedBuffer(bip39.mnemonicToSeed(backupMnemonic, ""), network);
+            backupPublicKey = backupPrivateKey.neutered();
+        }
+
+        backupPublicKey = [backupPublicKey.toBase58(), "M"];
+
+        // create a checksum of our private key which we'll later use to verify we used the right password
+        var checksum = primaryPrivateKey.getAddress().toBase58Check();
+
+        // send the public keys to the server to store them
+        //  and the mnemonic, which is safe because it's useless without the password
+        self._createNewWallet(
             identifier,
-            primaryMnemonic,
-            primaryPrivateKey,
+            primaryPublicKey,
             backupPublicKey,
-            blocktrailPubKeys,
-            keyIndex,
-            self.testnet
-        );
+            primaryMnemonic || false,
+            checksum,
+            keyIndex
+        )
+            .then(function(result) {
+                // received the blocktrail public keys
+                var blocktrailPubKeys = result.blocktrail_public_keys;
 
-        // if the response suggests we should upgrade to a different blocktrail cosigning key then we should
-        if (result.upgrade_key_index) {
-            wallet.upgradeKeyIndex(result.upgrade_key_index);
-        }
+                var wallet = new Wallet(
+                    self,
+                    identifier,
+                    primaryMnemonic,
+                    primaryPrivateKey,
+                    backupPublicKey,
+                    blocktrailPubKeys,
+                    keyIndex,
+                    self.testnet
+                );
 
-        return deferred.resolve([wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys]);
-    });
+                // if the response suggests we should upgrade to a different blocktrail cosigning key then we should
+                if (result.upgrade_key_index) {
+                    wallet.upgradeKeyIndex(result.upgrade_key_index);
+                }
+
+                return deferred.resolve([wallet, primaryMnemonic, backupMnemonic, blocktrailPubKeys]);
+            })
+            .fail(function(err) {
+                return deferred.reject(err);
+            });
+    })();
 
     return deferred.promise;
 };

--- a/lib/blocktrail.js
+++ b/lib/blocktrail.js
@@ -43,7 +43,7 @@ blocktrail.patchQ = function(Q) {
 
     Q.makePromise.prototype.spreadNodeify = function (nodeback) {
         if (nodeback) {
-            this.then(function (value) {
+            this.done(function (value) {
                 Q.nextTick(function () {
                     nodeback.apply(void 0, [null].concat(value));
                 });

--- a/lib/request.js
+++ b/lib/request.js
@@ -6,7 +6,7 @@ var https = require('https'),
     q = require('q'),
     crypto = require('crypto');
 
-var debug = require('debug')('blocktrail-sdk');
+var debug = require('debug')('blocktrail-sdk:request');
 
 var noop = function () {};
 


### PR DESCRIPTION
```javascript
client.createWallet({
    identifier: 'mycustomidentifier',
    primaryPrivateKey: 'xpriv...', // or bitcoin.HDNode instance
});

client.createWallet({
    identifier: 'mycustomidentifier',
    primaryMnemonic: 'my mnemonic should be strong',
    passphrase: 'password',
    storePrimaryMnemonic: false
});
```

had to redo the `initWallet` and `createNewWallet` to be able to accept more arguments, now takes an `object` instead, still supports old arguments through `arguments` for BC