### PR TITLE
[WIP] Coin Selection: allow DONTSIGN inputs

### DIFF
--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -31,7 +31,7 @@ var RestClient = function(options) {
     }
 
     self.defaultHeaders = {
-        'X-SDK-Version': 'blocktrail-sdk-nodejs/3.0.x'
+        'X-SDK-Version': 'blocktrail-sdk-nodejs/3.1.x'
     };
 };
 

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -9,6 +9,11 @@ var Encryption = require('./encryption');
 var EncryptionMnemonic = require('./encryption_mnemonic');
 var bip39 = require('bip39');
 
+var SignMode = {
+    SIGN: "sign",
+    DONT_SIGN: "dont_sign"
+};
+
 /**
  *
  * @param sdk                   APIClient       SDK instance used to do requests
@@ -772,6 +777,7 @@ Wallet.prototype.deleteWallet = function(force, cb) {
  * @returns {q.Promise}
  */
 Wallet.prototype.pay = function(pay, changeAddress, allowZeroConf, randomizeChangeIdx, feeStrategy, twoFactorToken, options, cb) {
+
     /* jshint -W071 */
     var self = this;
 
@@ -821,6 +827,7 @@ Wallet.prototype.pay = function(pay, changeAddress, allowZeroConf, randomizeChan
         )
             .spread(
             function(tx, utxos) {
+
                 deferred.notify(Wallet.PAY_PROGRESS_SEND);
 
                 return self.sendTransaction(tx.toHex(), utxos.map(function(utxo) { return utxo['path']; }), checkFee, twoFactorToken, options.prioboost)
@@ -1076,19 +1083,26 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                             deferred.notify(Wallet.PAY_PROGRESS_SIGN);
 
                             for (i = 0; i < utxos.length; i++) {
-                                path = utxos[i]['path'].replace("M", "m");
-
-                                if (self.primaryPrivateKey) {
-                                    privKey = Wallet.deriveByPath(self.primaryPrivateKey, path, "m").privKey;
-                                } else if (self.backupPrivateKey) {
-                                    privKey = Wallet.deriveByPath(self.backupPrivateKey, path.replace(/^m\/(\d+)\'/, 'm/$1'), "m").privKey;
-                                } else {
-                                    throw new Error("No master privateKey present");
+                                var mode = SignMode.SIGN;
+                                if (utxos[i].sign_mode) {
+                                    mode = utxos[i].sign_mode;
                                 }
 
-                                var redeemScript = bitcoin.Script.fromHex(utxos[i]['redeem_script']);
+                                if (mode === SignMode.SIGN) {
+                                    path = utxos[i]['path'].replace("M", "m");
 
-                                txb.sign(i, privKey, redeemScript);
+                                    if (self.primaryPrivateKey) {
+                                        privKey = Wallet.deriveByPath(self.primaryPrivateKey, path, "m").privKey;
+                                    } else if (self.backupPrivateKey) {
+                                        privKey = Wallet.deriveByPath(self.backupPrivateKey, path.replace(/^m\/(\d+)\'/, 'm/$1'), "m").privKey;
+                                    } else {
+                                        throw new Error("No master privateKey present");
+                                    }
+
+                                    var redeemScript = bitcoin.Script.fromHex(utxos[i]['redeem_script']);
+
+                                    txb.sign(i, privKey, redeemScript);
+                                }
                             }
 
                             tx = txb.buildIncomplete();


### PR DESCRIPTION
The SDK now accepts inputs from blocktrail which are marked 'dont_sign'.
These are counted towards the desired output value, and only included IFF
the input contributes it's at least the fee required to spend (making the  
operation free for the user)
