### PR TITLE
Insight custom host & WalletSweeper can recover altcoins

### DIFF
--- a/lib/services/insight_bitcoin_service.js
+++ b/lib/services/insight_bitcoin_service.js
@@ -22,13 +22,13 @@ var InsightBitcoinService = function(options) {
 
     // Backwards compatibility: change default host to bitpay
     // if host not set but testnet requested.
-    if (typeof options.host == 'undefined' && options.testnet) {
-        this.defaultSettings.host = InsightEndpointTestnet
+    if (typeof options.host === 'undefined' && options.testnet) {
+        this.defaultSettings.host = InsightEndpointTestnet;
     }
 
     this.settings = _.merge({}, this.defaultSettings, options);
-    this.DEFAULT_ENDPOINT_MAINNET = InsightEndpointMainnet
-    this.DEFAULT_ENDPOINT_TESTNET = InsightEndpointTestnet
+    this.DEFAULT_ENDPOINT_MAINNET = InsightEndpointMainnet;
+    this.DEFAULT_ENDPOINT_TESTNET = InsightEndpointTestnet;
 };
 
 /**
@@ -112,7 +112,7 @@ InsightBitcoinService.prototype.estimateFee = function() {
  * @param hex
  * @returns {*}
  */
-InsightBitcoinService.prototype.sendTx = function (hex) {
+InsightBitcoinService.prototype.sendTx = function(hex) {
     return this.postEndpoint('tx/send', {rawtx: hex});
 };
 
@@ -120,8 +120,8 @@ InsightBitcoinService.prototype.sendTx = function (hex) {
  * Makes a URL from the endpoint and issues a GET request.
  * @param endpoint
  */
-InsightBitcoinService.prototype.getEndpoint = function (endpoint) {
-    return this.getRequest(this.settings.host + '/' + endpoint)
+InsightBitcoinService.prototype.getEndpoint = function(endpoint) {
+    return this.getRequest(this.settings.host + '/' + endpoint);
 };
 
 /**
@@ -132,7 +132,7 @@ InsightBitcoinService.prototype.getEndpoint = function (endpoint) {
  * @returns {promise|Function|*}
  */
 InsightBitcoinService.prototype.postEndpoint = function(endpoint, data) {
-    return this.postRequest(this.settings.host + '/' + endpoint, data)
+    return this.postRequest(this.settings.host + '/' + endpoint, data);
 };
 
 /**

--- a/lib/services/insight_bitcoin_service.js
+++ b/lib/services/insight_bitcoin_service.js
@@ -3,6 +3,9 @@ var request = require('superagent');
 var _ = require('lodash');
 var q = require('q');
 
+var InsightEndpointMainnet = 'https://insight.bitpay.com/api';
+var InsightEndpointTestnet = 'https://test-insight.bitpay.com/api';
+
 /**
  *
  * @param options
@@ -10,12 +13,22 @@ var q = require('q');
  */
 var InsightBitcoinService = function(options) {
     this.defaultSettings = {
-        testnet:    false,
+        host: InsightEndpointMainnet,
+        testnet: false,
 
         retryLimit: 5,
-        retryDelay:  20
+        retryDelay: 20
     };
+
+    // Backwards compatibility: change default host to bitpay
+    // if host not set but testnet requested.
+    if (typeof options.host == 'undefined' && options.testnet) {
+        this.defaultSettings.host = InsightEndpointTestnet
+    }
+
     this.settings = _.merge({}, this.defaultSettings, options);
+    this.DEFAULT_ENDPOINT_MAINNET = InsightEndpointMainnet
+    this.DEFAULT_ENDPOINT_TESTNET = InsightEndpointTestnet
 };
 
 /**
@@ -32,7 +45,7 @@ InsightBitcoinService.prototype.getBatchUnspentOutputs = function(addresses) {
 
     //get unspent outputs for the chunk of addresses - required data: hash, index, value, and script hex,
     var data = {"addrs": addresses.join(',')};
-    self.postRequest("https://" + (self.settings.testnet ? 'test-' : '') + 'insight.bitpay.com/api/addrs/utxo', data).then(function(results) {
+    self.postEndpoint('addrs/utxo', data).then(function(results) {
         var batchResults = {};  //utxos mapped to addresses
 
         //reduce the returned data into the values we're interested in, and map to the relevant addresses
@@ -70,7 +83,7 @@ InsightBitcoinService.prototype.batchAddressHasTransactions = function(addresses
     var self = this;
 
     var data = {"addrs": addresses.join(',')};
-    return self.postRequest("https://" + (self.settings.testnet ? 'test-' : '') + 'insight.bitpay.com/api/addrs/txs', data)
+    return self.postEndpoint('addrs/txs', data)
         .then(function(results) {
             return results.items.length > 0;
         })
@@ -87,13 +100,46 @@ InsightBitcoinService.prototype.estimateFee = function() {
 
     var nBlocks = "2";
 
-    return self.getRequest("https://" + (self.settings.testnet ? 'test-' : '') + 'insight.bitpay.com/api/utils/estimatefee?nbBlocks=' + nBlocks)
+    return self.getEndpoint('utils/estimatefee?nbBlocks=' + nBlocks)
         .then(function(results) {
             return parseInt(results[nBlocks] * 1e8, 10);
         })
     ;
 };
 
+/**
+ * Submit a raw transaction hex to the tx/send endpoint
+ * @param hex
+ * @returns {*}
+ */
+InsightBitcoinService.prototype.sendTx = function (hex) {
+    return this.postEndpoint('tx/send', {rawtx: hex});
+};
+
+/**
+ * Makes a URL from the endpoint and issues a GET request.
+ * @param endpoint
+ */
+InsightBitcoinService.prototype.getEndpoint = function (endpoint) {
+    return this.getRequest(this.settings.host + '/' + endpoint)
+};
+
+/**
+ * Makes URL from endpoint and issues a POST request.
+ *
+ * @param endpoint
+ * @param data
+ * @returns {promise|Function|*}
+ */
+InsightBitcoinService.prototype.postEndpoint = function(endpoint, data) {
+    return this.postRequest(this.settings.host + '/' + endpoint, data)
+};
+
+/**
+ * Makes a GET request to url
+ * @param url
+ * @returns {promise|Function|*}
+ */
 InsightBitcoinService.prototype.getRequest = function(url) {
     var deferred = q.defer();
     request
@@ -123,8 +169,16 @@ InsightBitcoinService.prototype.getRequest = function(url) {
     return deferred.promise;
 };
 
+/**
+ * Makes a POST request given the url and data
+ *
+ * @param url
+ * @param data
+ * @returns {promise|Function|*}
+ */
 InsightBitcoinService.prototype.postRequest = function(url, data) {
     var deferred = q.defer();
+
     request
         .post(url)
         .send(data)

--- a/lib/wallet_sweeper.js
+++ b/lib/wallet_sweeper.js
@@ -32,7 +32,9 @@ var WalletSweeper = function(backupData, bitcoinDataClient, options) {
     this.sweepData = null;
 
     // set the bitcoinlib network
-    this.network = this.getBitcoinNetwork(this.settings.network, this.settings.testnet);
+    if (typeof options.recoveryNetwork == "object") {
+        this.recoveryNetwork = options.recoveryNetwork;
+    }
 
     backupData.walletVersion = backupData.walletVersion || 2;   //default to version 2 wallets
 
@@ -277,7 +279,12 @@ WalletSweeper.prototype.createAddress = function(path) {
     ]);
     var redeemScript = bitcoin.scripts.multisigOutput(2, multisigKeys);
     var scriptPubKey = bitcoin.scripts.scriptHashOutput(redeemScript.getHash());
-    var address = bitcoin.Address.fromOutputScript(scriptPubKey, this.network);
+
+    var network = this.network
+    if (typeof this.recoveryNetwork != "undefined") {
+        network = this.recoveryNetwork
+    }
+    var address = bitcoin.Address.fromOutputScript(scriptPubKey, network);
 
     //@todo return as buffers
     return {address: address.toString(), redeem: redeemScript};

--- a/lib/wallet_sweeper.js
+++ b/lib/wallet_sweeper.js
@@ -32,7 +32,7 @@ var WalletSweeper = function(backupData, bitcoinDataClient, options) {
     this.sweepData = null;
 
     // set the bitcoinlib network
-    if (typeof options.recoveryNetwork == "object") {
+    if (typeof options.recoveryNetwork === "object") {
         this.recoveryNetwork = options.recoveryNetwork;
     }
 
@@ -280,9 +280,9 @@ WalletSweeper.prototype.createAddress = function(path) {
     var redeemScript = bitcoin.scripts.multisigOutput(2, multisigKeys);
     var scriptPubKey = bitcoin.scripts.scriptHashOutput(redeemScript.getHash());
 
-    var network = this.network
-    if (typeof this.recoveryNetwork != "undefined") {
-        network = this.recoveryNetwork
+    var network = this.network;
+    if (typeof this.recoveryNetwork !== "undefined") {
+        network = this.recoveryNetwork;
     }
     var address = bitcoin.Address.fromOutputScript(scriptPubKey, network);
 

--- a/test/insight_bitcoin_service.test.js
+++ b/test/insight_bitcoin_service.test.js
@@ -1,0 +1,80 @@
+/* jshint -W101, -W098 */
+var blocktrail = require('../');
+var assert = require('assert');
+var crypto = require('crypto');
+var q = require('q');
+
+describe('InsightBitcoinService', function() {
+    it('defaults to bitpay on mainnet', function(cb) {
+        var insight = new blocktrail.InsightBitcoinService({});
+        assert.equal(insight.settings.host, insight.DEFAULT_ENDPOINT_MAINNET);
+        assert.equal(insight.settings.testnet, false);
+        cb();
+    });
+
+    it('uses bitpays testnet server if host is not set', function(cb) {
+        var insight = new blocktrail.InsightBitcoinService({
+            testnet: true
+        });
+        assert.equal(insight.settings.host, insight.DEFAULT_ENDPOINT_TESTNET);
+        assert.equal(insight.settings.testnet, true);
+        cb();
+    });
+
+    it('uses bitpays testnet server if host is not set', function(cb) {
+        var insight = new blocktrail.InsightBitcoinService({
+            testnet: true
+        });
+        assert.equal(insight.settings.host, insight.DEFAULT_ENDPOINT_TESTNET);
+        assert.equal(insight.settings.testnet, true);
+        cb();
+    });
+
+    [true, false].map(function(testnet) {
+        var network = testnet ? 'testnet' : 'mainnet';
+        var host = 'insight.litecore.io';
+
+        it('ignores testnet option if host is set: ' + network, function(cb) {
+            var insight = new blocktrail.InsightBitcoinService({
+                host: host,
+                testnet: testnet
+            });
+            assert.equal(insight.settings.host, host);
+            assert.equal(insight.settings.testnet, testnet);
+            cb();
+        });
+    });
+
+    [
+        ['POST', 'object', function(insight) {
+            return insight.getBatchUnspentOutputs(['mpFnXKEomQw8DBxbDfD9PXZuMvXRxVoAEo']);
+        }],
+        ['GET', 'number', function(insight) {
+            return insight.estimateFee();
+        }]
+    ].map(function(fixture) {
+        var method = fixture[0];
+        var resultType = fixture[1];
+        var fxn = fixture[2];
+        it('issues ' + method + ' requests', function(cb) {
+            this.timeout(10000);
+            var insight = new blocktrail.InsightBitcoinService({
+                testnet: true
+            });
+
+            var deferred = q.defer();
+            fxn(insight)
+                .then(function(result) {
+                    assert.equal(resultType, typeof result);
+                    deferred.resolve(true);
+                }, function() {
+                    deferred.resolve(false);
+                });
+
+            deferred.promise.then(function(result) {
+                assert.equal(true, result);
+                cb();
+            });
+        });
+    });
+});


### PR DESCRIPTION
insight_bitcoin_service:
 * allow custom host (which means the testnet param will be ignored)
 * tests for existing bitpay api and for custom host
 * adds sendTx method

wallet_sweeper:
 * allow setting recoveryNetwork to replace call to getBitcoinNetwork
   (makes it possible to recover coins on a network besides bitcoin,
    while continuing to use a mainnet/testnet3 backup sheet)