### PR TITLE
Segwit support

### DIFF
--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -839,6 +839,13 @@ APIClient.prototype.unsubscribeNewBlocks = function(identifier, cb) {
     return self.client.delete("/webhook/" + identifier + "/block", null, null, cb);
 };
 
+function getDefaultChainIndex(isBitcoinCash) {
+    if (isBitcoinCash) {
+        return Wallet.CHAIN_BCC_DEFAULT;
+    }
+    return Wallet.CHAIN_BTC_SEGWIT;
+}
+
 /**
  * initialize an existing wallet
  *
@@ -903,7 +910,7 @@ APIClient.prototype.initWallet = function(options, cb) {
             backupPublicKey,
             blocktrailPublicKeys,
             keyIndex,
-            result.chain || 0,
+            getDefaultChainIndex(this.bitcoinCash),
             self.testnet,
             result.checksum,
             result.upgrade_key_index,
@@ -1679,17 +1686,25 @@ APIClient.prototype.sendTransaction = function(identifier, txHex, paths, checkFe
         prioboost = false;
     }
 
+    var data = {
+        paths: paths,
+        two_factor_token: twoFactorToken
+    };
+    if (typeof txHex === "string") {
+        data.raw_transaction = txHex
+    } else if (typeof txHex === "object") {
+        Object.keys(txHex).map(function (key) {
+            data[key] = txHex[key]
+        })
+    }
+
     return self.client.post(
         "/wallet/" + identifier + "/send",
         {
             check_fee: checkFee ? 1 : 0,
             prioboost: prioboost ? 1 : 0
         },
-        {
-            raw_transaction: txHex,
-            paths: paths,
-            two_factor_token: twoFactorToken
-        },
+        data,
         cb
     );
 };

--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -1691,11 +1691,11 @@ APIClient.prototype.sendTransaction = function(identifier, txHex, paths, checkFe
         two_factor_token: twoFactorToken
     };
     if (typeof txHex === "string") {
-        data.raw_transaction = txHex
+        data.raw_transaction = txHex;
     } else if (typeof txHex === "object") {
-        Object.keys(txHex).map(function (key) {
-            data[key] = txHex[key]
-        })
+        Object.keys(txHex).map(function(key) {
+            data[key] = txHex[key];
+        });
     }
 
     return self.client.post(

--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -839,13 +839,6 @@ APIClient.prototype.unsubscribeNewBlocks = function(identifier, cb) {
     return self.client.delete("/webhook/" + identifier + "/block", null, null, cb);
 };
 
-function getDefaultChainIndex(isBitcoinCash) {
-    if (isBitcoinCash) {
-        return Wallet.CHAIN_BCC_DEFAULT;
-    }
-    return Wallet.CHAIN_BTC_SEGWIT;
-}
-
 /**
  * initialize an existing wallet
  *
@@ -910,7 +903,8 @@ APIClient.prototype.initWallet = function(options, cb) {
             backupPublicKey,
             blocktrailPublicKeys,
             keyIndex,
-            getDefaultChainIndex(this.bitcoinCash),
+            result.chain || 0,
+            result.segwit || 0,
             self.testnet,
             result.checksum,
             result.upgrade_key_index,
@@ -1094,6 +1088,7 @@ APIClient.prototype._createNewWalletV1 = function(options) {
                                     blocktrailPublicKeys,
                                     keyIndex,
                                     result.chain || 0,
+                                    result.segwit || 0,
                                     self.testnet,
                                     checksum,
                                     result.upgrade_key_index,
@@ -1203,6 +1198,7 @@ APIClient.prototype._createNewWalletV2 = function(options) {
                         blocktrailPublicKeys,
                         keyIndex,
                         result.chain || 0,
+                        result.segwit || 0,
                         self.testnet,
                         checksum,
                         result.upgrade_key_index,
@@ -1313,6 +1309,7 @@ APIClient.prototype._createNewWalletV3 = function(options) {
                             blocktrailPublicKeys,
                             keyIndex,
                             result.chain || 0,
+                            result.segwit || 0,
                             self.testnet,
                             checksum,
                             result.upgrade_key_index,

--- a/lib/size_estimation.js
+++ b/lib/size_estimation.js
@@ -1,0 +1,280 @@
+var assert = require('assert');
+var bitcoin = require('bitcoinjs-lib');
+
+var SizeEstimation = {
+    SIZE_DER_SIGNATURE: 72,
+    SIZE_V0_P2WSH: 36
+};
+
+SizeEstimation.getPublicKeySize = function(isCompressed) {
+    return isCompressed ? 33 : 65;
+};
+
+SizeEstimation.getLengthForScriptPush = function(length) {
+    if (length < 75) {
+        return 1;
+    } else if (length <= 0xff) {
+        return 2;
+    } else if (length <= 0xffff) {
+        return 3;
+    } else if (length <= 0xffffffff) {
+        return 5;
+    } else {
+        throw new Error("Size of pushdata too large");
+    }
+};
+
+SizeEstimation.getLengthForVarInt = function(length) {
+    if (length < 253) {
+        return 1;
+    }
+
+    // Rest have a prefix byte
+    var numBytes;
+    if (length < 65535) {
+        numBytes = 2;
+    } else if (length < 4294967295) {
+        numBytes = 4;
+    } else if (length < 18446744073709551615) {
+        numBytes = 8;
+    } else {
+        throw new Error("Size of varint too large");
+    }
+
+    return 1 + numBytes;
+};
+
+SizeEstimation.estimateMultisigStackSize = function(m, keys) {
+    // Initialize with OP_0
+    var stackSizes = [0];
+    var i;
+    for (i = 0; i < m; i++) {
+        stackSizes.push(SizeEstimation.SIZE_DER_SIGNATURE);
+    }
+
+    var scriptSize = 1; // OP_$m
+    for (i = 0; i < keys.length; i++) {
+        scriptSize += this.getLengthForScriptPush(keys[i].length) + keys[i].length;
+    }
+    scriptSize += 2; // OP_$n OP_CHECKMULTISIG
+    return [stackSizes, scriptSize];
+};
+
+
+SizeEstimation.estimateMultisigStackSize = function(m, keys) {
+    // Initialize with OP_0
+    var stackSizes = [0];
+    var i;
+    for (i = 0; i < m; i++) {
+        stackSizes.push(SizeEstimation.SIZE_DER_SIGNATURE);
+    }
+
+    var scriptSize = 1; // OP_$m
+    for (i = 0; i < keys.length; i++) {
+        scriptSize += this.getLengthForScriptPush(keys[i].length) + keys[i].length;
+    }
+    scriptSize += 2; // OP_$n OP_CHECKMULTISIG
+    return [stackSizes, scriptSize];
+};
+
+SizeEstimation.estimateP2PKStackSize = function(key) {
+    var stackSizes = [SizeEstimation.SIZE_DER_SIGNATURE];
+    var scriptSize = this.getLengthForScriptPush(key.length) + key.length + 1; // KEY OP_CHECKSIG
+
+    return [stackSizes, scriptSize];
+};
+
+SizeEstimation.estimateP2PKHStackSize = function(isCompressed) {
+    if (typeof isCompressed === 'undefined') {
+        isCompressed = true;
+    }
+
+    var stackSizes = [this.SIZE_DER_SIGNATURE, this.getPublicKeySize(isCompressed)];
+    var scriptSize = 2 + this.getLengthForScriptPush(20) + 2;
+
+    return [stackSizes, scriptSize];
+};
+
+/**
+ * As pure a function as it gets, but without the overhead
+ * of checking everything. Make sure your calls are correct.
+ *
+ * @param {Buffer} stackSizes
+ * @param {Buffer} isWitness
+ * @param {Buffer} rs
+ * @param {Buffer} ws
+ */
+SizeEstimation.estimateStackSignatureSize = function(stackSizes, isWitness, rs, ws) {
+    assert(ws === null || isWitness);
+
+    var scriptSigSizes = [];
+    var witnessSizes = [];
+    if (isWitness) {
+        witnessSizes = stackSizes;
+        if (ws instanceof Buffer) {
+            witnessSizes.push(ws.length);
+        }
+    } else {
+        scriptSigSizes = stackSizes;
+    }
+
+    if (rs instanceof Buffer) {
+        scriptSigSizes.push(rs.length);
+    }
+
+    var self = this;
+    var scriptSigSize = 0;
+    scriptSigSizes.map(function(elementLen) {
+        scriptSigSize += self.getLengthForScriptPush(elementLen) + elementLen;
+    });
+
+    scriptSigSize += self.getLengthForVarInt(scriptSigSize);
+
+    var witnessSize = 0;
+    if (witnessSizes.length > 0) {
+        witnessSizes.map(function(elementLen) {
+            witnessSize += self.getLengthForVarInt(elementLen) + elementLen;
+        });
+        witnessSize += self.getLengthForVarInt(witnessSizes.length);
+    }
+
+    return [scriptSigSize, witnessSize];
+};
+
+/**
+ *
+ * @param {Buffer} script - main script, can equal RS/WS too
+ * @param {Buffer} redeemScript
+ * @param {Buffer} witnessScript
+ * @param {boolean} isWitness - required, covers P2WPKH and so on
+ */
+SizeEstimation.estimateInputFromScripts = function(script, redeemScript, witnessScript, isWitness) {
+    assert(witnessScript === null || isWitness);
+
+    var stackSizes;
+    if (bitcoin.script.multisig.output.check(script)) {
+        var multisig = bitcoin.script.multisig.output.decode(script);
+        stackSizes = this.estimateMultisigStackSize(multisig.m, multisig.pubKeys)[0];
+    } else if (bitcoin.script.pubKey.output.check(script)) {
+        var p2pk = bitcoin.script.pubKey.output.decode(script);
+        stackSizes = this.estimateP2PKStackSize(p2pk);
+    } else if (bitcoin.script.pubKeyHash.output.check(script)) {
+        // assumes compressed
+        stackSizes = this.estimateP2PKHStackSize(true);
+    } else {
+        throw new Error("Unsupported script type");
+    }
+
+    return this.estimateStackSignatureSize(stackSizes, isWitness, redeemScript, witnessScript);
+};
+
+SizeEstimation.estimateUtxo = function(utxo) {
+    var spk = Buffer.from(utxo.scriptpubkey_hex, 'hex');
+    var rs = typeof utxo.redeem_script === 'string' ? Buffer.from(utxo.redeem_script, 'hex') : null;
+    var ws = typeof utxo.witness_script === 'string' ? Buffer.from(utxo.witness_script, 'hex') : null;
+    var witness = false;
+
+    var signScript = spk;
+    if (bitcoin.script.scriptHash.output.check(signScript)) {
+        if (null === rs) {
+            throw new Error("Cant estimate, missing redeem script");
+        }
+        signScript = rs;
+    }
+
+    if (bitcoin.script.witnessPubKeyHash.output.check(signScript)) {
+        var p2wpkh = bitcoin.script.witnessPubKeyHash.output.decode(signScript);
+        signScript = bitcoin.script.pubKeyHash.encode(p2wpkh);
+        witness = true;
+    } else if (bitcoin.script.witnessScriptHash.output.check(signScript)) {
+        if (null === ws) {
+            throw new Error("Can't estimate, missing witness script");
+        }
+        signScript = ws;
+        witness = true;
+    }
+
+    var types = bitcoin.script.types;
+    var allowedTypes = [types.MULTISIG, types.P2PKH, types.P2PK];
+    var type = bitcoin.script.classifyOutput(signScript);
+    if (allowedTypes.indexOf(type) === -1) {
+        throw new Error("Unsupported script type");
+    }
+
+    var estimation = this.estimateInputFromScripts(signScript, rs, ws, witness);
+
+    return {
+        scriptSig: estimation[0],
+        witness: estimation[1]
+    };
+};
+
+/**
+ * Returns the size of input related data, given a set
+ * of utxos we can estimate for. witness data is included
+ * if withWitness=true, and is required for vsize/weight
+ * calculations
+ * @param {object} utxos
+ * @param {boolean} withWitness
+ * @returns {number}
+ */
+SizeEstimation.estimateInputsSize = function(utxos, withWitness) {
+    var inputSize = 0;
+    var witnessSize = 0;
+    utxos.map(function(utxo) {
+        var estimate = SizeEstimation.estimateUtxo(utxo);
+        inputSize += 32 + 4 + 4 + estimate.scriptSig;
+        if (withWitness) {
+            witnessSize += estimate.witness;
+        }
+    });
+
+    if (withWitness && witnessSize > 0) {
+        inputSize += 2 + witnessSize;
+    }
+
+    return inputSize;
+};
+
+/**
+ * Calculates number of bytes to serialize tx outputs
+ * @param {Array} outs
+ * @returns {number}
+ */
+SizeEstimation.calculateOutputsSize = function(outs) {
+    var outputsSize = 0;
+    outs.map(function(out) {
+        var scriptSize = SizeEstimation.getLengthForVarInt(out.script.length / 2);
+        outputsSize += 8 + scriptSize + (out.script.length / 2);
+    });
+    return outputsSize;
+};
+
+/**
+ * Returns the transactions weight.
+ *
+ * @param {bitcoin.Transaction} tx
+ * @param {array} utxos
+ * @returns {*}
+ */
+SizeEstimation.estimateTxWeight = function(tx, utxos) {
+    var outSize = SizeEstimation.calculateOutputsSize(tx.outs);
+    var baseSize = 4 + 4 + this.estimateInputsSize(utxos, false) + 4 + outSize + 4;
+    var witSize = 4 + 4 + this.estimateInputsSize(utxos, false) + 4 + outSize + 4;
+    return (3 * baseSize) + witSize;
+};
+
+
+/**
+ * Returns the vsize for a transaction. Same as size
+ * for transaction with no witness data.
+ *
+ * @param {bitcoin.Transaction} tx
+ * @param {array} utxos
+ * @returns {Number}
+ */
+SizeEstimation.estimateTxVsize = function(tx, utxos) {
+    return parseInt(Math.ceil(SizeEstimation.estimateTxWeight(tx, utxos) / 4), 10);
+};
+
+module.exports = SizeEstimation;

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -29,6 +29,7 @@ var SignMode = {
  * @param blocktrailPublicKeys  array           list of blocktrail pubKeys indexed by keyIndex
  * @param keyIndex              int             key index to use
  * @param chain                 int             chain to use
+ * @param segwit                int             segwit toggle from server
  * @param testnet               bool            testnet
  * @param checksum              string
  * @param upgradeToKeyIndex     int
@@ -48,6 +49,7 @@ var Wallet = function(
     blocktrailPublicKeys,
     keyIndex,
     chain,
+    segwit,
     testnet,
     checksum,
     upgradeToKeyIndex,
@@ -62,6 +64,7 @@ var Wallet = function(
     self.locked = true;
     self.bypassNewAddressCheck = !!bypassNewAddressCheck;
     self.bitcoinCash = self.sdk.bitcoinCash;
+    assert(segwit === 0 || !self.bitcoinCash);
 
     self.testnet = testnet;
     if (self.testnet) {
@@ -88,7 +91,19 @@ var Wallet = function(
     self.blocktrailPublicKeys = blocktrailPublicKeys;
     self.primaryPublicKeys = primaryPublicKeys;
     self.keyIndex = keyIndex;
-    self.chain = chain;
+
+    var chainIdx;
+    if (!self.bitcoinCash) {
+        if (segwit) {
+            chainIdx = Wallet.CHAIN_BTC_SEGWIT;
+        } else {
+            chainIdx = Wallet.CHAIN_BTC_DEFAULT;
+        }
+    } else {
+        chainIdx = Wallet.CHAIN_BCC_DEFAULT;
+    }
+
+    self.chain = chainIdx;
     self.checksum = checksum;
     self.upgradeToKeyIndex = upgradeToKeyIndex;
 
@@ -121,6 +136,10 @@ Wallet.FEE_STRATEGY_BASE_FEE = blocktrail.FEE_STRATEGY_BASE_FEE;
 Wallet.FEE_STRATEGY_OPTIMAL = blocktrail.FEE_STRATEGY_OPTIMAL;
 Wallet.FEE_STRATEGY_LOW_PRIORITY = blocktrail.FEE_STRATEGY_LOW_PRIORITY;
 Wallet.FEE_STRATEGY_MIN_RELAY_FEE = blocktrail.FEE_STRATEGY_MIN_RELAY_FEE;
+
+Wallet.prototype.isSegwit = function() {
+    return Wallet.CHAIN_BTC_SEGWIT === this.chain;
+};
 
 Wallet.prototype.unlock = function(options, cb) {
     var self = this;
@@ -547,7 +566,7 @@ Wallet.prototype.getWalletScriptByPath = function(path) {
     var scriptType = parseInt(path.split("/")[2]);
 
     var ws, rs;
-    if (this.network !== "bitcoincash" && scriptType === 2) {
+    if (this.network !== "bitcoincash" && scriptType === Wallet.CHAIN_BTC_SEGWIT) {
         ws = multisig;
         rs = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(ws));
     } else {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -8,6 +8,7 @@ var blocktrail = require('./blocktrail');
 var CryptoJS = require('crypto-js');
 var Encryption = require('./encryption');
 var EncryptionMnemonic = require('./encryption_mnemonic');
+var SizeEstimation = require('./size_estimation');
 var bip39 = require('bip39');
 
 var SignMode = {
@@ -934,16 +935,16 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
             try {
                 addr = bitcoin.address.fromBech32(address, self.network);
                 err = null;
-                type = "bech32"
+                type = "bech32";
             } catch (_err) {
-                err = _err
+                err = _err;
             }
 
             if (!addr) {
                 try {
                     addr = bitcoin.address.fromBase58Check(address, self.network);
                     err = null;
-                    type = "base58"
+                    type = "base58";
                 } catch (_err) {
                     err = _err;
                 }
@@ -968,9 +969,9 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                 value: parseInt(value, 10)
             };
             if (type === "bech32") {
-                payload.scriptPubKey = bitcoin.address.toOutputScript(address, self.network).toString('hex')
+                payload.scriptPubKey = bitcoin.address.toOutputScript(address, self.network).toString('hex');
             } else {
-                payload.address = address
+                payload.address = address;
             }
             send.push(payload);
         });
@@ -1131,7 +1132,7 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                          * @param cb
                          */
                         function(cb) {
-                            var i, privKey, path;
+                            var i, privKey, path, redeemScript, witnessScript;
 
                             deferred.notify(Wallet.PAY_PROGRESS_SIGN);
 
@@ -1141,6 +1142,8 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                                     mode = utxos[i].sign_mode;
                                 }
 
+                                redeemScript = null;
+                                witnessScript = null;
                                 if (mode === SignMode.SIGN) {
                                     path = utxos[i]['path'].replace("M", "m");
 
@@ -1153,8 +1156,7 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                                         throw new Error("No master privateKey present");
                                     }
 
-                                    var redeemScript = new Buffer(utxos[i]['redeem_script'], 'hex');
-                                    var witnessScript;
+                                    redeemScript = new Buffer(utxos[i]['redeem_script'], 'hex');
                                     if (typeof utxos[i]['witness_script'] === 'string') {
                                         witnessScript = new Buffer(utxos[i]['witness_script'], 'hex');
                                     }
@@ -1178,8 +1180,7 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                          * @param cb
                          */
                         function(cb) {
-
-                            var estimatedFee = Wallet.estimateIncompleteTxFee(tx);
+                            var estimatedFee = Wallet.estimateVsizeFee(tx, utxos);
 
                             switch (feeStrategy) {
                                 case Wallet.FEE_STRATEGY_BASE_FEE:
@@ -1447,6 +1448,7 @@ Wallet.sortMultiSigKeys = function(pubKeys) {
  * determine how much fee is required based on the inputs and outputs
  *  this is an estimation, not a proper 100% correct calculation
  *
+ * @todo: mark deprecated in favor of estimations where UTXOS are known
  * @param {bitcoin.Transaction} tx
  * @param {int} feePerKb when not null use this feePerKb, otherwise use BASE_FEE legacy calculation
  * @returns {number}
@@ -1455,6 +1457,28 @@ Wallet.estimateIncompleteTxFee = function(tx, feePerKb) {
     var size = Wallet.estimateIncompleteTxSize(tx);
     var sizeKB = size / 1000;
     var sizeKBCeil = Math.ceil(size / 1000);
+
+    if (feePerKb) {
+        return parseInt(sizeKB * feePerKb, 10);
+    } else {
+        return parseInt(sizeKBCeil * blocktrail.BASE_FEE, 10);
+    }
+};
+
+/**
+ * Takes tx and utxos, computing their estimated vsize,
+ * and uses feePerKb (or BASEFEE as default) to estimate
+ * the number of satoshis in fee.
+ *
+ * @param {bitcoin.Transaction} tx
+ * @param {Array} utxos
+ * @param feePerKb
+ * @returns {Number}
+ */
+Wallet.estimateVsizeFee = function(tx, utxos, feePerKb) {
+    var vsize = SizeEstimation.estimateTxVsize(tx, utxos);
+    var sizeKB = vsize / 1000;
+    var sizeKBCeil = Math.ceil(vsize / 1000);
 
     if (feePerKb) {
         return parseInt(sizeKB * feePerKb, 10);
@@ -1543,6 +1567,7 @@ Wallet.estimateIncompleteTxSize = function(tx) {
  *  this is an estimation, not a proper 100% correct calculation
  *  this asumes all inputs are 2of3 multisig
  *
+ * @todo: mark deprecated in favor of situations where UTXOS are known
  * @param txinCnt       {number}
  * @param txoutCnt      {number}
  * @returns {number}

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -508,14 +508,7 @@ Wallet.prototype.passwordChange = function(newPassword, cb) {
  * @returns string
  */
 Wallet.prototype.getAddressByPath = function(path) {
-    var self = this;
-
-    var redeemScript = self.getRedeemScriptByPath(path);
-    var scriptHash = bitcoin.crypto.hash160(redeemScript);
-    var scriptPubKey = bitcoin.script.scriptHash.output.encode(scriptHash);
-    var address = bitcoin.address.fromOutputScript(scriptPubKey, self.network);
-
-    return address.toString();
+    return this.getWalletScriptByPath(path).address;
 };
 
 /**
@@ -525,6 +518,10 @@ Wallet.prototype.getAddressByPath = function(path) {
  * @returns {bitcoin.Script}
  */
 Wallet.prototype.getRedeemScriptByPath = function(path) {
+    return this.getWalletScriptByPath(path).redeemScript;
+};
+
+Wallet.prototype.getWalletScriptByPath = function(path) {
     var self = this;
 
     // get derived primary key
@@ -541,8 +538,27 @@ Wallet.prototype.getRedeemScriptByPath = function(path) {
         derivedBlocktrailPublicKey.keyPair.getPublicKeyBuffer()
     ]);
 
-    // create multisig
-    return bitcoin.script.multisig.output.encode(2, pubKeys);
+    var multisig = bitcoin.script.multisig.output.encode(2, pubKeys);
+    var scriptType = parseInt(path.split("/")[2]);
+
+    var ws, rs;
+    if (this.network !== "bitcoincash" && scriptType === 2) {
+        ws = multisig;
+        rs = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(ws));
+    } else {
+        ws = null;
+        rs = multisig;
+    }
+
+    var spk = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(rs));
+    var addr = bitcoin.address.fromOutputScript(spk, this.network);
+
+    return {
+        witnessScript: ws,
+        redeemScript: rs,
+        scriptPubKey: spk,
+        address: addr
+    };
 };
 
 /**
@@ -1097,6 +1113,7 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                                 if (mode === SignMode.SIGN) {
                                     path = utxos[i]['path'].replace("M", "m");
 
+                                    // todo: regenerate scripts for path and compare for utxo (paranoid mode)
                                     if (self.primaryPrivateKey) {
                                         privKey = Wallet.deriveByPath(self.primaryPrivateKey, path, "m").keyPair;
                                     } else if (self.backupPrivateKey) {
@@ -1106,13 +1123,17 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                                     }
 
                                     var redeemScript = new Buffer(utxos[i]['redeem_script'], 'hex');
+                                    var witnessScript;
+                                    if (typeof utxos[i]['witness_script'] !== 'undefined') {
+                                        witnessScript = new Buffer(utxos[i]['witness_script'], 'hex');
+                                    }
 
                                     var sigHash = bitcoin.Transaction.SIGHASH_ALL;
                                     if (self.bitcoinCash) {
                                         sigHash |= bitcoin.Transaction.SIGHASH_BITCOINCASHBIP143;
                                     }
 
-                                    txb.sign(i, privKey, redeemScript, sigHash, utxos[i].value);
+                                    txb.sign(i, privKey, redeemScript, sigHash, utxos[i].value, witnessScript);
                                 }
                             }
 

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -111,6 +111,10 @@ Wallet.PAY_PROGRESS_SIGN = 30;
 Wallet.PAY_PROGRESS_SEND = 40;
 Wallet.PAY_PROGRESS_DONE = 100;
 
+Wallet.CHAIN_BTC_DEFAULT = 0;
+Wallet.CHAIN_BTC_SEGWIT = 2;
+Wallet.CHAIN_BCC_DEFAULT = 1;
+
 Wallet.FEE_STRATEGY_FORCE_FEE = blocktrail.FEE_STRATEGY_FORCE_FEE;
 Wallet.FEE_STRATEGY_BASE_FEE = blocktrail.FEE_STRATEGY_BASE_FEE;
 Wallet.FEE_STRATEGY_OPTIMAL = blocktrail.FEE_STRATEGY_OPTIMAL;
@@ -664,8 +668,8 @@ Wallet.prototype.getNewAddress = function(cb) {
                 var path = newDerivation.path;
                 var address = newDerivation.address;
                 if (!self.bypassNewAddressCheck) {
-                    address = self.getAddressByPath(newDerivation.path);
 
+                    address = self.getAddressByPath(newDerivation.path);
                     // debug check
                     if (address !== newDerivation.address) {
                         throw new blocktrail.WalletAddressError("Failed to verify address [" + newDerivation.address + "] !== [" + address + "]");
@@ -851,7 +855,12 @@ Wallet.prototype.pay = function(pay, changeAddress, allowZeroConf, randomizeChan
 
                 deferred.notify(Wallet.PAY_PROGRESS_SEND);
 
-                return self.sendTransaction(tx.toHex(), utxos.map(function(utxo) { return utxo['path']; }), checkFee, twoFactorToken, options.prioboost)
+                var data = {
+                    signed_transaction: tx.toHex(),
+                    base_transaction: tx.__toBuffer(null, null, false).toString('hex')
+                };
+
+                return self.sendTransaction(data, utxos.map(function(utxo) { return utxo['path']; }), checkFee, twoFactorToken, options.prioboost)
                     .then(function(result) {
                         deferred.notify(Wallet.PAY_PROGRESS_DONE);
 
@@ -920,10 +929,24 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
             }
 
             var addr;
+            var type;
+
             try {
-                addr = bitcoin.address.fromBase58Check(address, self.network);
+                addr = bitcoin.address.fromBech32(address, self.network);
+                err = null;
+                type = "bech32"
             } catch (_err) {
-                err = _err;
+                err = _err
+            }
+
+            if (!addr) {
+                try {
+                    addr = bitcoin.address.fromBase58Check(address, self.network);
+                    err = null;
+                    type = "base58"
+                } catch (_err) {
+                    err = _err;
+                }
             }
 
             if (!addr || err) {
@@ -941,7 +964,15 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
                 return deferred.promise;
             }
 
-            send.push({address: address, value: parseInt(value, 10)});
+            var payload = {
+                value: parseInt(value, 10)
+            };
+            if (type === "bech32") {
+                payload.scriptPubKey = bitcoin.address.toOutputScript(address, self.network).toString('hex')
+            } else {
+                payload.address = address
+            }
+            send.push(payload);
         });
 
         if (!send.length) {
@@ -1124,7 +1155,7 @@ Wallet.prototype.buildTransaction = function(pay, changeAddress, allowZeroConf, 
 
                                     var redeemScript = new Buffer(utxos[i]['redeem_script'], 'hex');
                                     var witnessScript;
-                                    if (typeof utxos[i]['witness_script'] !== 'undefined') {
+                                    if (typeof utxos[i]['witness_script'] === 'string') {
                                         witnessScript = new Buffer(utxos[i]['witness_script'], 'hex');
                                     }
 

--- a/lib/wallet_sweeper.js
+++ b/lib/wallet_sweeper.js
@@ -295,7 +295,7 @@ WalletSweeper.prototype.createAddress = function(path) {
 
     var multisig = bitcoin.script.multisig.output.encode(2, multisigKeys);
     var redeemScript, witnessScript;
-    if (this.network !== "bitcoincash" && scriptType === 2) {
+    if (this.network !== "bitcoincash" && scriptType === walletSDK.CHAIN_BTC_SEGWIT) {
         witnessScript = multisig;
         redeemScript = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript));
     } else {

--- a/lib/wallet_sweeper.js
+++ b/lib/wallet_sweeper.js
@@ -425,7 +425,7 @@ WalletSweeper.prototype.discoverWalletFunds = function(increment, cb) {
                                                 _.each(utxos, function(outputs, address) {
                                                     var witnessScript = null;
                                                     if (typeof batch[address]['witness'] !== 'undefined') {
-                                                        witnessScript = batch[address]['witness']
+                                                        witnessScript = batch[address]['witness'];
 
                                                     }
                                                     addressUTXOs[address] = {
@@ -621,7 +621,19 @@ WalletSweeper.prototype.createTransaction = function(destinationAddress, fee, fe
                 message: "estimating transaction fee, based on " + blocktrail.toBTC(feePerKb) + " BTC/kb"
             });
         }
-        fee = walletSDK.estimateIncompleteTxFee(rawTransaction.tx, feePerKb);
+        var calcUtxos = inputs.map(function(input) {
+            return {
+                txid: input.txid,
+                vout: input.vout,
+                address: input.vout,
+                scriptpubkey_hex: input.vout,
+                redeem_script: input.redeemScript,
+                witness_script: input.witnessScript,
+                path: input.path,
+                value: input.value
+            };
+        });
+        fee = walletSDK.estimateVsizeFee(rawTransaction.tx, calcUtxos, feePerKb);
     }
     rawTransaction.tx.outs[outputIdx].value -= fee;
 

--- a/lib/wallet_sweeper.js
+++ b/lib/wallet_sweeper.js
@@ -277,6 +277,7 @@ WalletSweeper.prototype.createAddress = function(path) {
     //ensure a public path is used
     path = path.replace("m", "M");
     var keyIndex = path.split("/")[1].replace("'", "");
+    var scriptType = parseInt(path.split("/")[2]);
 
     //derive the primary pub key directly from the primary priv key
     var primaryPubKey = walletSDK.deriveByPath(this.primaryPrivateKey, path, "m");
@@ -291,7 +292,16 @@ WalletSweeper.prototype.createAddress = function(path) {
         backupPubKey.keyPair.getPublicKeyBuffer(),
         blocktrailPubKey.keyPair.getPublicKeyBuffer()
     ]);
-    var redeemScript = bitcoin.script.multisig.output.encode(2, multisigKeys);
+
+    var multisig = bitcoin.script.multisig.output.encode(2, multisigKeys);
+    var redeemScript, witnessScript;
+    if (this.network !== "bitcoincash" && scriptType === 2) {
+        witnessScript = multisig;
+        redeemScript = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript));
+    } else {
+        witnessScript = null;
+        redeemScript = multisig;
+    }
     var scriptHash = bitcoin.crypto.hash160(redeemScript);
     var scriptPubKey = bitcoin.script.scriptHash.output.encode(scriptHash);
 
@@ -302,7 +312,7 @@ WalletSweeper.prototype.createAddress = function(path) {
     var address = bitcoin.address.fromOutputScript(scriptPubKey, network);
 
     //@todo return as buffers
-    return {address: address.toString(), redeem: redeemScript};
+    return {address: address.toString(), redeem: redeemScript, witness: witnessScript};
 };
 
 /**
@@ -324,6 +334,7 @@ WalletSweeper.prototype.createBatchAddresses = function(start, count, keyIndex, 
         var multisig = self.createAddress(path);
         addresses[multisig['address']] = {
             redeem: multisig['redeem'],
+            witness: multisig['witness'],
             path: path
         };
     })).then(function() {
@@ -344,10 +355,17 @@ WalletSweeper.prototype.discoverWalletFunds = function(increment, cb) {
     var deferred = q.defer();
     deferred.promise.nodeify(cb);
 
+    var checkChain;
+    if (this.network === "bitcoincash") {
+        checkChain = [0, 1];
+    } else {
+        checkChain = [0, 1, 2];
+    }
+
     async.nextTick(function() {
         //for each blocktrail pub key, do fund discovery on batches of addresses
         async.eachSeries(Object.keys(self.blocktrailPublicKeys), function(keyIndex, done) {
-            async.eachSeries([0, 1], function(chain, done) {
+            async.eachSeries(checkChain, function(chain, done) {
                 var i = 0;
                 var hasTransactions = false;
 
@@ -405,11 +423,18 @@ WalletSweeper.prototype.discoverWalletFunds = function(increment, cb) {
                                             return self.utxoFinder.getUTXOs(_.keys(batch)).then(function(utxos) {
                                                 // save the address utxos, along with relevant path and redeem script
                                                 _.each(utxos, function(outputs, address) {
+                                                    var witnessScript = null;
+                                                    if (typeof batch[address]['witness'] !== 'undefined') {
+                                                        witnessScript = batch[address]['witness']
+
+                                                    }
                                                     addressUTXOs[address] = {
                                                         path: batch[address]['path'],
                                                         redeem: batch[address]['redeem'],
+                                                        witness: witnessScript,
                                                         utxos: outputs
                                                     };
+
                                                     totalUTXOs += outputs.length;
 
                                                     //add up the total utxo value for all addresses
@@ -577,7 +602,8 @@ WalletSweeper.prototype.createTransaction = function(destinationAddress, fee, fe
                 value:        utxo['value'],
                 address:      address,
                 path:         data['path'],
-                redeemScript: data['redeem']
+                redeemScript: data['redeem'],
+                witnessScript: data['witness']
             });
         });
     });
@@ -623,11 +649,11 @@ WalletSweeper.prototype.signTransaction = function(rawTransaction, inputs) {
     _.each(inputs, function(input, index) {
         //create private keys for signing
         var primaryPrivKey =  walletSDK.deriveByPath(self.primaryPrivateKey, input['path'].replace("M", "m"), "m").keyPair;
-        rawTransaction.sign(index, primaryPrivKey, input['redeemScript'], sigHash, input['value']);
+        rawTransaction.sign(index, primaryPrivKey, input['redeemScript'], sigHash, input['value'], input['witnessScript']);
 
         if (self.backupPrivateKey) {
             var backupPrivKey = walletSDK.deriveByPath(self.backupPrivateKey, input['path'].replace("'", "").replace("M", "m"), "m").keyPair;
-            rawTransaction.sign(index, backupPrivKey, input['redeemScript'], sigHash, input['value']);
+            rawTransaction.sign(index, backupPrivKey, input['redeemScript'], sigHash, input['value'], input['witnessScript']);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "assert-plus": "0.1.5",
     "async": "0.9.0",
     "bip39": "git://github.com/blocktrail/bip39.git#sjcl-browser-bip39",
-    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#374d5897b296630ae2f81a5df2b46eb367e4e99b",
+    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#f2880529a96701eaf83de4084e9bc0c479c609fe",
     "bitcoinjs-message": "^1.0.1",
     "bops": "0.0.6",
     "bowser": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "assert-plus": "0.1.5",
     "async": "0.9.0",
     "bip39": "git://github.com/blocktrail/bip39.git#sjcl-browser-bip39",
-    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#f2880529a96701eaf83de4084e9bc0c479c609fe",
+    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#88f784f185775247b951093af96b89dd1aa2951b",
     "bitcoinjs-message": "^1.0.1",
     "bops": "0.0.6",
     "bowser": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "assert-plus": "0.1.5",
     "async": "0.9.0",
     "bip39": "git://github.com/blocktrail/bip39.git#sjcl-browser-bip39",
-    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#88f784f185775247b951093af96b89dd1aa2951b",
+    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#ce1c5e9e684b77b015f82f698e8d726ebe9f0a15",
     "bitcoinjs-message": "^1.0.1",
     "bops": "0.0.6",
     "bowser": "^0.7.2",

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ exports = module.exports = {
     api_client: require('./test/api_client.test'),
     api_client_promises: require('./test/api_client-promises.test'),
     crypto: require('./test/crypto.test'),
+    size_estimation: require('./test/size_estimation.test'),
     wallet: require('./test/wallet.test'),
     buffer: require('./test/buffer.test')
 };

--- a/test/size_estimation.test.js
+++ b/test/size_estimation.test.js
@@ -1,0 +1,250 @@
+/* jshint -W101, -W098 */
+/* global window */
+var assert = require('assert');
+var bitcoin = require('bitcoinjs-lib');
+var SizeEstimation = require("../lib/size_estimation");
+
+var varIntFixtures = [
+    [0, 1],
+    [1, 1],
+    [252, 1],
+    [253, 3],
+    [254, 3],
+    [65534, 3],
+    [65535, 5],
+    [65536, 5],
+    [Math.pow(2, 31), 5],
+    [Math.pow(2, 32) - 2, 5],
+    [Math.pow(2, 32) - 1, 9],
+    [Math.pow(2, 32), 9],
+
+    // don't go above this, is signed int territory, PHP complains
+    // nodejs?
+    [0x7fffffffffffffff, 9]
+];
+
+var scriptDataLenFixtures =  [
+    [0, 1],
+    [1, 1],
+    [74, 1],
+    [75, 2],
+    [76, 2],
+    [254, 2],
+    [255, 2],
+    [256, 3],
+    [65534, 3],
+    [65535, 3],
+    [65536, 5]
+];
+
+var multisigStackFixtures = (function() {
+    var u = ['5KW8Ymmu8gWManGggZZQJeX7U3pn5HtcqqsVrNUbc1SUmVPZbwp',
+        '5KCV94YBsrJWTdk6cQWJxEd25sH8h1cGTpJnCN6kLMLe4c3QZVr',
+        '5JUxGateMWVBsBQkAwSRQLxyaQXhsch4EStfC62cqdEf2zUheVT'
+    ];
+    var c = ['L1Tr4rPUi81XN1Dp48iuva5U9sWxU1eipgiAu8BhnB3xnSfGV5rd',
+        'KwUZpCvpAkUe1SZj3k3P2acta1V1jY8Dpuj71bEAukEKVrg8NEym',
+        'Kz2Lm2hzjPWhv3WW9Na5HUKi4qBxoTfv8fNYAU6KV6TZYVGdK5HW'
+    ];
+    var uncompressed = u.map(function(wif) {
+        return bitcoin.ECPair.fromWIF(wif, bitcoin.networks.bitcoin);
+    });
+    var compressed = c.map(function(wif) {
+        return bitcoin.ECPair.fromWIF(wif, bitcoin.networks.bitcoin);
+    });
+
+    var fixtures = [];
+    for (var i = 0; i < 3; i++) {
+        var keys = [];
+        var j;
+        for (j = 0; j < i; j++) {
+            keys.push(uncompressed[j].getPublicKeyBuffer());
+        }
+        for (j = i; j < 3; j++) {
+            keys.push(compressed[j].getPublicKeyBuffer());
+        }
+
+        fixtures.push([bitcoin.script.multisig.output.encode(2, keys)]);
+    }
+
+    return fixtures;
+})();
+
+// test fixtures of every possible representation of multisig
+var multisigFormFixtures = (function() {
+    var c = ['L1Tr4rPUi81XN1Dp48iuva5U9sWxU1eipgiAu8BhnB3xnSfGV5rd',
+        'KwUZpCvpAkUe1SZj3k3P2acta1V1jY8Dpuj71bEAukEKVrg8NEym',
+        'Kz2Lm2hzjPWhv3WW9Na5HUKi4qBxoTfv8fNYAU6KV6TZYVGdK5HW'
+    ];
+    var keys = c.map(function(wif) {
+        return bitcoin.ECPair.fromWIF(wif, bitcoin.networks.bitcoin).getPublicKeyBuffer();
+    });
+    var multisig = bitcoin.script.multisig.output.encode(2, keys);
+    var bareSize = 1/*op0*/ + 2 * (1 + SizeEstimation.SIZE_DER_SIGNATURE);
+
+    var bareSig = 1 + bareSize;
+    var p2shSig = 3 + bareSize + 2 + multisig.length;
+
+    var p2wshHash = bitcoin.crypto.sha256(multisig);
+    var p2wshScript = bitcoin.script.witnessScriptHash.output.encode(p2wshHash);
+
+    var nestedSig = 1 + 1 + p2wshScript.length;
+    var witSize = 1 + 2 * (1 + SizeEstimation.SIZE_DER_SIGNATURE);
+    var nestedWit = witSize + 1 + 1 + multisig.length;
+
+    return [
+        [multisig, false, null, null, bareSig, 0],
+        [multisig, false, multisig, null, p2shSig, 0],
+        [multisig, true, null, multisig, 1, nestedWit],
+        [multisig, true, p2wshScript, multisig, nestedSig, nestedWit]
+    ];
+})();
+
+function makeUtxo(script, rs, ws) {
+    var utxo = {
+        scriptpubkey_hex: script.toString('hex'),
+        value: 100000000
+    };
+    if (rs instanceof Buffer) {
+        utxo.redeem_script = rs.toString('hex');
+    }
+    if (ws instanceof Buffer) {
+        utxo.witness_script = ws.toString('hex');
+    }
+    return utxo;
+}
+
+// test fixtures of every possible representation of multisig
+var multisigUtxoFixtures = (function() {
+    var c = ['L1Tr4rPUi81XN1Dp48iuva5U9sWxU1eipgiAu8BhnB3xnSfGV5rd',
+        'KwUZpCvpAkUe1SZj3k3P2acta1V1jY8Dpuj71bEAukEKVrg8NEym',
+        'Kz2Lm2hzjPWhv3WW9Na5HUKi4qBxoTfv8fNYAU6KV6TZYVGdK5HW'
+    ];
+    var keys = c.map(function(wif) {
+        return bitcoin.ECPair.fromWIF(wif, bitcoin.networks.bitcoin).getPublicKeyBuffer();
+    });
+    var multisig = bitcoin.script.multisig.output.encode(2, keys);
+    var bareSize = 1/*op0*/ + 2 * (1 + SizeEstimation.SIZE_DER_SIGNATURE);
+
+    var bareSig = 1 + bareSize;
+    var p2shSig = 3 + bareSize + 2 + multisig.length;
+
+    var p2wshHash = bitcoin.crypto.sha256(multisig);
+    var p2wshScript = bitcoin.script.witnessScriptHash.output.encode(p2wshHash);
+
+    var nestedSig = 1 + 1 + p2wshScript.length;
+    var witSize = 1 + 2 * (1 + SizeEstimation.SIZE_DER_SIGNATURE);
+    var nestedWit = witSize + 1 + 1 + multisig.length;
+
+    var multisigHash160 = bitcoin.crypto.hash160(multisig);
+    var multisigP2sh = bitcoin.script.scriptHash.output.encode(multisigHash160);
+
+    var multisigSha256 = bitcoin.crypto.sha256(multisig);
+    var multisigP2wsh = bitcoin.script.witnessScriptHash.output.encode(multisigSha256);
+
+    var p2wshHash160 = bitcoin.crypto.hash160(multisigP2wsh);
+    var p2wshP2sh = bitcoin.script.scriptHash.output.encode(p2wshHash160);
+
+    var bareUtxo = makeUtxo(multisig, null, null);
+    var p2shUtxo = makeUtxo(multisigP2sh, multisig, null);
+    var p2wshUtxo = makeUtxo(multisigP2wsh, null, multisig);
+    var p2shP2wshUtxo = makeUtxo(p2wshP2sh, p2wshScript, multisig);
+
+    return [
+        [bareUtxo, bareSig, 0],
+        [p2shUtxo, p2shSig, 0],
+        [p2wshUtxo, 1, nestedWit],
+        [p2shP2wshUtxo, nestedSig, nestedWit]
+    ];
+})();
+
+describe('getLengthForVarInt', function() {
+    varIntFixtures.map(function(fixture) {
+        var inputLen = fixture[0];
+        var expectSize = fixture[1];
+        it('works for `' + inputLen + '` (equals ' + expectSize + ')', function(cb) {
+            var result = SizeEstimation.getLengthForVarInt(inputLen);
+            assert.equal(expectSize, result);
+            cb();
+        });
+    });
+});
+
+describe('getLengthForScriptPush', function() {
+    scriptDataLenFixtures.map(function(fixture) {
+        var inputLen = fixture[0];
+        var expectSize = fixture[1];
+        it(' works for ' + inputLen + '` (equals ' + expectSize + ')', function(cb) {
+            var result = SizeEstimation.getLengthForScriptPush(inputLen);
+            assert.equal(expectSize, result);
+            cb();
+        });
+    });
+});
+
+describe("estimateMultisigStackSize", function() {
+    multisigStackFixtures.map(function(fixture) {
+        it("works for multisig scripts with the keys", function(cb) {
+            var script = fixture[0];
+            assert.ok(bitcoin.script.multisig.output.check(script));
+            var decoded = bitcoin.script.multisig.output.decode(script);
+            var estimation = SizeEstimation.estimateMultisigStackSize(decoded.m, decoded.pubKeys);
+
+            assert.equal("object", typeof estimation);
+            assert.equal(2, estimation.length);
+
+            var scriptSize = estimation[1];
+            assert.equal(script.length, scriptSize);
+
+            var stackSizes = estimation[0];
+            assert.equal(1 + decoded.m, stackSizes.length);
+            assert.equal(0, stackSizes[0]);
+            for (var i = 0; i < decoded.m; i++) {
+                assert.equal(SizeEstimation.SIZE_DER_SIGNATURE, stackSizes[1 + i]);
+            }
+            cb();
+        });
+    });
+
+    multisigFormFixtures.map(function(fixture) {
+        it("deals with different representations", function(cb) {
+            var script = fixture[0];
+            var isWit = fixture[1];
+            var rs = fixture[2];
+            var ws = fixture[3];
+            var expectSig = fixture[4];
+            var expectWit = fixture[5];
+
+            assert.ok(bitcoin.script.multisig.output.check(script));
+            var multisig = bitcoin.script.multisig.output.decode(script);
+
+            var stackEst = SizeEstimation.estimateMultisigStackSize(multisig.m, multisig.pubKeys);
+            var stackSizes = stackEst[0];
+
+            var est = SizeEstimation.estimateStackSignatureSize(stackSizes, isWit, rs, ws);
+            assert.equal("object", typeof est);
+            assert.equal(2, est.length);
+
+            var foundSigSize = est[0];
+            var foundWitSize = est[1];
+
+            assert.equal(foundSigSize, expectSig);
+            assert.equal(foundWitSize, expectWit);
+            cb();
+        });
+    });
+
+    multisigUtxoFixtures.map(function(fixture) {
+        it("deals with different representations", function(cb) {
+            var utxo = fixture[0];
+            var expectSig = fixture[1];
+            var expectWit = fixture[2];
+
+            var estimate = SizeEstimation.estimateUtxo(utxo);
+
+            assert.equal(estimate.scriptSig, expectSig);
+            assert.equal(estimate.witness, expectWit);
+            cb();
+        });
+    });
+});

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -868,35 +868,35 @@ describe('test wallet, do transaction', function() {
 });
 
 describe('test wallet with segwit chain', function() {
-    var wallet
+    var wallet;
 
-    it("should exist and be setup", function (cb) {
+    it("should exist and be setup", function(cb) {
         client.initWallet({
             identifier: "unittest-transaction",
             passphrase: TRANSACTION_TEST_WALLET_PASSWORD
-        }, function (err, _wallet) {
+        }, function(err, _wallet) {
             assert.ifError(err);
             assert.ok(_wallet);
             assert.equal(_wallet.primaryMnemonic, "give pause forget seed dance crawl situate hole keen");
             assert.equal(_wallet.identifier, "unittest-transaction");
             assert.equal(_wallet.getBlocktrailPublicKey("M/9999'").toBase58(), "tpubD9q6vq9zdP3gbhpjs7n2TRvT7h4PeBhxg1Kv9jEc1XAss7429VenxvQTsJaZhzTk54gnsHRpgeeNMbm1QTag4Wf1QpQ3gy221GDuUCxgfeZ");
-            assert.equal(blocktrail.Wallet.CHAIN_BTC_SEGWIT, _wallet.chain)
+            assert.equal(blocktrail.Wallet.CHAIN_BTC_SEGWIT, _wallet.chain);
             wallet = _wallet;
-            cb()
-        })
+            cb();
+        });
     });
 
-    it("getNewAddress produces P2SH addresses", function (cb) {
-        wallet.getNewAddress(function (err, address, path) {
+    it("getNewAddress produces P2SH addresses", function(cb) {
+        wallet.getNewAddress(function(err, address, path) {
             assert.ifError(err);
             assert.ok(path.indexOf("M/9999'/2/") === 0);
             assert.ok(bitcoin.address.fromBase58Check(address));
 
             cb();
-        })
+        });
     });
 
-    it("getWalletScriptByPath produces P2SH addresses, and returns witnessScript", function (cb) {
+    it("getWalletScriptByPath produces P2SH addresses, and returns witnessScript", function(cb) {
         var eAddress = "2N3j4Vx3D9LPumjtRbRe2RJpwVocvCCkHKh";
 
         assert.equal(wallet.getAddressByPath("M/9999'/2/0"), eAddress);
@@ -905,7 +905,7 @@ describe('test wallet with segwit chain', function() {
         assert.equal(walletScript.address, eAddress);
         assert.ok(walletScript.witnessScript);
         assert.ok(walletScript.redeemScript);
-        cb()
+        cb();
     });
 });
 
@@ -913,9 +913,9 @@ describe('test wallet, do transaction, segwit spend', function() {
     var wallets = [];
     after(function(cb) {
         if (wallets.length > 0) {
-            wallets.map(function(wallet){
+            wallets.map(function(wallet) {
                 wallet.deleteWallet(true);
-            })
+            });
         }
         cb();
     });
@@ -925,32 +925,32 @@ describe('test wallet, do transaction, segwit spend', function() {
     var segwitWallet;
     var receiveAddr;
     var receiveBackAddr;
-    it("should setup the funding wallet", function (cb) {
+    it("should setup the funding wallet", function(cb) {
         client.initWallet({
             identifier: "unittest-transaction",
             passphrase: TRANSACTION_TEST_WALLET_PASSWORD
-        }, function (err, _wallet) {
+        }, function(err, _wallet) {
             assert.ifError(err);
             assert.ok(_wallet);
 
-            _wallet.getNewAddress(function (err, address, path) {
+            _wallet.getNewAddress(function(err, address, path) {
                 assert.ifError(err);
                 assert.ok(address);
                 assert.ok(path);
 
                 unitTestWallet = _wallet;
                 receiveBackAddr = address;
-                cb()
-            })
-        })
+                cb();
+            });
+        });
     });
 
     it("should make the receiving segwit wallet ", function(cb) {
-        createTransactionTestWallet(identifier, function (err, newWallet) {
-            wallets.push(newWallet)
+        createTransactionTestWallet(identifier, function(err, newWallet) {
+            wallets.push(newWallet);
             assert.ifError(err);
             newWallet.chain = blocktrail.Wallet.CHAIN_BTC_SEGWIT;
-            newWallet.getNewAddress(function (err, address, path) {
+            newWallet.getNewAddress(function(err, address, path) {
                 assert.ifError(err);
                 assert.ok(bitcoin.address.fromBase58Check(address));
                 assert.ok(path.indexOf("M/9999'/2/") === 0);
@@ -962,38 +962,37 @@ describe('test wallet, do transaction, segwit spend', function() {
 
                 segwitWallet = newWallet;
                 receiveAddr = address;
-                cb()
-            })
-        })
+                cb();
+            });
+        });
     });
 
     var paymentHash;
     it("should receive funds from unitTestWallet", function(cb) {
         var pay = {};
         pay[receiveAddr] = 30000;
-        unitTestWallet.pay(pay, null, true, function (err, txid) {
+        unitTestWallet.pay(pay, null, true, function(err, txid) {
             assert.ifError(err);
             assert.ok(txid);
             paymentHash = txid;
-            cb()
-        })
+            cb();
+        });
     });
 
     it("should return to unitTestWallet", function(cb) {
         var pay = {};
         pay[receiveBackAddr] = 20000;
-        segwitWallet.pay(pay, null, true, function (err, txid) {
+        segwitWallet.pay(pay, null, true, function(err, txid) {
             assert.ifError(err);
             assert.ok(txid);
 
-            client.transaction(txid, function (err, tx) {
+            client.transaction(txid, function(err, tx) {
                 assert.ifError(err);
                 assert.ok(tx);
-                cb()
+                cb();
             });
-        })
-    })
-
+        });
+    });
 });
 describe('test wallet, do transaction, without mnemonics', function() {
     var wallet;

--- a/tools/setup-dev-account.js
+++ b/tools/setup-dev-account.js
@@ -29,7 +29,7 @@ var _createTestWallet = function(identifier, passphrase, primaryMnemonic, backup
     var backupPrivateKey = bitcoin.HDNode.fromSeedBuffer(backupSeed, network);
     var backupPublicKey = backupPrivateKey.neutered();
 
-    var checksum = primaryPrivateKey.getAddress().toBase58Check();
+    var checksum = primaryPrivateKey.getAddress();
     var primaryPublicKey = primaryPrivateKey.deriveHardened(keyIndex).neutered();
 
     client.storeNewWalletV1(
@@ -59,6 +59,7 @@ var _createTestWallet = function(identifier, passphrase, primaryMnemonic, backup
                 backupPublicKey,
                 blocktrailPublicKeys,
                 keyIndex,
+                0,
                 client.testnet,
                 checksum
             );


### PR DESCRIPTION
Work in progress, still needs review, please don't use until this is merged & backend supports it too, you will have a bad time

adds:
support for P2SH|P2WSH segwit scripts
better size estimation
manage address types using wallet chain field in bip32path.

tests cover most of the spend/receive cases, and stuff like paying to bech32 addresses

(cancelling travis tests, review please)