### PR TITLE
bump to latest blocktrail/bitcoinjs-lib blocktrail-v3.2.0 commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "assert-plus": "0.1.5",
     "async": "0.9.0",
     "bip39": "git://github.com/blocktrail/bip39.git#sjcl-browser-bip39",
-    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#blocktrail-v3.2.0",
+    "bitcoinjs-lib": "git://github.com/blocktrail/bitcoinjs-lib.git#0b5fb93747ae7aeb4fa41d068f6bb04c40460503",
     "bitcoinjs-message": "^1.0.1",
     "bops": "0.0.6",
     "bowser": "^0.7.2",


### PR DESCRIPTION
uses newer bitcoinjs-lib version that accepts short cashaddresses by retrying validation _with_ the networks cashAddrPrefix.