### PR TITLE
require-activation flag

### DIFF
--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -1464,7 +1464,8 @@ APIClient.prototype._createNewWalletV1 = function(options) {
                             options.storePrimaryMnemonic ? options.primaryMnemonic : false,
                             checksum,
                             keyIndex,
-                            options.segwit || null
+                            options.segwit || null,
+                            options.require_activation || false
                         )
                             .then(function(result) {
                                 deferred.notify(APIClient.CREATE_WALLET_PROGRESS_INIT);
@@ -1574,7 +1575,8 @@ APIClient.prototype._createNewWalletV2 = function(options) {
                 checksum,
                 keyIndex,
                 options.support_secret || null,
-                options.segwit || null
+                options.segwit || null,
+                options.require_activation || false
             )
                 .then(
                 function(result) {
@@ -1684,7 +1686,8 @@ APIClient.prototype._createNewWalletV3 = function(options) {
                 checksum,
                 keyIndex,
                 options.support_secret || null,
-                options.segwit || null
+                options.segwit || null,
+                options.require_activation || false
             )
                 .then(
                     // result, deferred, self(apiclient)
@@ -1770,10 +1773,11 @@ function verifyPublicOnly(walletData, network) {
  * @param checksum              string      checksum to store
  * @param keyIndex              int         keyIndex that was used to create wallet
  * @param segwit                bool
+ * @param requireActivation     bool
  * @returns {q.Promise}
  */
 APIClient.prototype.storeNewWalletV1 = function(identifier, primaryPublicKey, backupPublicKey, primaryMnemonic,
-                                                checksum, keyIndex, segwit) {
+                                                checksum, keyIndex, segwit, requireActivation) {
     var self = this;
 
     var postData = {
@@ -1786,6 +1790,10 @@ APIClient.prototype.storeNewWalletV1 = function(identifier, primaryPublicKey, ba
         key_index: keyIndex,
         segwit: segwit
     };
+
+    if (requireActivation) {
+        postData.require_activation = true
+    }
 
     verifyPublicOnly(postData, self.network);
 
@@ -1805,10 +1813,11 @@ APIClient.prototype.storeNewWalletV1 = function(identifier, primaryPublicKey, ba
  * @param keyIndex              int         keyIndex that was used to create wallet
  * @param supportSecret         string
  * @param segwit                bool
+ * @param requireActivation     bool
  * @returns {q.Promise}
  */
 APIClient.prototype.storeNewWalletV2 = function(identifier, primaryPublicKey, backupPublicKey, encryptedPrimarySeed, encryptedSecret,
-                                                recoverySecret, checksum, keyIndex, supportSecret, segwit) {
+                                                recoverySecret, checksum, keyIndex, supportSecret, segwit, requireActivation) {
     var self = this;
 
     var postData = {
@@ -1824,6 +1833,10 @@ APIClient.prototype.storeNewWalletV2 = function(identifier, primaryPublicKey, ba
         support_secret: supportSecret || null,
         segwit: segwit
     };
+
+    if (requireActivation) {
+        postData.require_activation = true
+    }
 
     verifyPublicOnly(postData, self.network);
 
@@ -1843,10 +1856,11 @@ APIClient.prototype.storeNewWalletV2 = function(identifier, primaryPublicKey, ba
  * @param keyIndex              int         keyIndex that was used to create wallet
  * @param supportSecret         string
  * @param segwit                bool
+ * @param requireActivation     bool
  * @returns {q.Promise}
  */
 APIClient.prototype.storeNewWalletV3 = function(identifier, primaryPublicKey, backupPublicKey, encryptedPrimarySeed, encryptedSecret,
-                                                recoverySecret, checksum, keyIndex, supportSecret, segwit) {
+                                                recoverySecret, checksum, keyIndex, supportSecret, segwit, requireActivation) {
     var self = this;
 
     var postData = {
@@ -1862,6 +1876,10 @@ APIClient.prototype.storeNewWalletV3 = function(identifier, primaryPublicKey, ba
         support_secret: supportSecret || null,
         segwit: segwit
     };
+
+    if (requireActivation) {
+        postData.require_activation = true
+    }
 
     verifyPublicOnly(postData, self.network);
 


### PR DESCRIPTION
relevant for dashboard created wallets - want a way to avoid showing them until developers download the backup PDF